### PR TITLE
Fix typo in branch creation instructions

### DIFF
--- a/.github/steps/1-create-a-branch.md
+++ b/.github/steps/1-create-a-branch.md
@@ -56,6 +56,6 @@ GitHub shows your profile README at the top of your profile page. For more infor
 <summary>Having trouble? 🤷</summary><br/>
 
 If you don't get feedback, here are some things to check:
-- Make sure your created the branch with the exact name `my-first-branch`. No prefixes or suffixes.
+- Make sure you created the branch with the exact name `my-first-branch`. No prefixes or suffixes.
 
 </details>


### PR DESCRIPTION
## Summary
- correct the phrase "Make sure your created" to "Make sure you created"

## Testing
- `git status --short`